### PR TITLE
Added the code to maintain important fields weeklyStudyTime, monthlyStudyTime, todayBreaks, and todayBreaks

### DIFF
--- a/src/components/features/focusList/AddFocus.jsx
+++ b/src/components/features/focusList/AddFocus.jsx
@@ -54,7 +54,8 @@ export default function AddFocus({ isAddFocusVisible, setIsAddFocusVisible }) {
             duration: durationInt,
             location: location, // optional field
             lastUpdate: Timestamp.fromDate(now),
-            break: 0,
+            todayBreaks: 0,
+            todayTimes: 0,
             weeklyStudyTime: new Array(7).fill(0), // 7 days in a week
             monthlyStudyTime: new Array(12).fill(0), // 12 months in a year
           };

--- a/src/components/features/focusList/EditFocus.jsx
+++ b/src/components/features/focusList/EditFocus.jsx
@@ -5,7 +5,7 @@ import InputWithLabel from '../../ui/InputWithLabel';
 import FormOperationBar from '../../ui/FormOperationBar';
 import { Colors } from '../../../utils/Colors';
 import { auth, db } from '../../../api/FirestoreConfig';
-import { updateDoc, deleteDoc, doc, Timestamp } from 'firebase/firestore';
+import { updateDoc, deleteDoc, doc, Timestamp, getDoc } from 'firebase/firestore';
 import { AntDesign } from '@expo/vector-icons';
 
 export default function EditFocus({ isEditFocusVisible, setIsEditFocusVisible, focusID }) {
@@ -14,15 +14,29 @@ export default function EditFocus({ isEditFocusVisible, setIsEditFocusVisible, f
   const [location, setLocation] = useState(null);
   const user = auth.currentUser;
 
-
-  // use useEffect to reset the form when modal is closed
+  // when isEditFocusVisible becomes true and when focusID changes,
+  // useEffect will fetch the current data of the focus task and populates the state variables
   useEffect(() => {
-    if (!isEditFocusVisible) {
-      setTitle("");
-      setDuration("");
-      setLocation(null);
-    }
-  }, [isEditFocusVisible]);
+    const fetchFocusData = async () => {
+      if (focusID && isEditFocusVisible) {
+        const focusRef = doc(db, "users", auth.currentUser.uid, "focus", focusID);
+        const docSnap = await getDoc(focusRef);
+
+        if (docSnap.exists()) {
+          const focusData = docSnap.data();
+          setTitle(focusData.title || "");
+          setDuration(focusData.duration.toString() || ""); 
+          setLocation(focusData.location || null);
+        } else {
+          console.log("No such document!");
+        }
+      }
+    };
+
+    fetchFocusData();
+  }, [isEditFocusVisible, focusID]);
+
+  
 
   // check the title and the durarion are valid
   const validateInput = () => {

--- a/src/components/features/focusList/EditFocus.jsx
+++ b/src/components/features/focusList/EditFocus.jsx
@@ -25,7 +25,7 @@ export default function EditFocus({ isEditFocusVisible, setIsEditFocusVisible, f
         if (docSnap.exists()) {
           const focusData = docSnap.data();
           setTitle(focusData.title || "");
-          setDuration(focusData.duration.toString() || ""); 
+          setDuration(parseInt(focusData.duration, 10) || ""); 
           setLocation(focusData.location || null);
         } else {
           console.log("No such document!");
@@ -72,7 +72,7 @@ export default function EditFocus({ isEditFocusVisible, setIsEditFocusVisible, f
     try {
       await updateDoc(focusRef, {
         title: title,
-        duration: duration,
+        duration: parseInt(duration, 10),
       })
       console.log("Focus task updated!");
       setIsEditFocusVisible(false);

--- a/src/components/screens/FocusScreen.jsx
+++ b/src/components/screens/FocusScreen.jsx
@@ -59,9 +59,10 @@ export default function FocusScreen() {
     }
   }, []);
 
-  const onStartPress = (duration) => {
-    navigation.navigate('Standby', { duration});
-  }
+  const onStartPress = (focusID, duration) => {
+    navigation.navigate('Standby', { focusID, duration });
+  };
+ 
 
   return (
     <View style={styles.container}>
@@ -72,7 +73,7 @@ export default function FocusScreen() {
           <FocusCard
             title={item.title}
             duration={item.duration}
-            onStartPress={() => onStartPress(item.duration)} // Pass the duration to onStartPress
+            onStartPress={() => onStartPress(item.id, item.duration)} // Pass the duration to onStartPress
             onEditPress={() => {
               setIsEditFocusVisible(true);
               setSelectedFocusID(item.id); // pass the focus item id to the EditFocus Modal


### PR DESCRIPTION
## In StandbyScreen
### Logic of Maintaining `weeklyStudyTime` and `monthlyStudyTime` Arrays
1. **Same Day**: If the completion is on the same day as `lastUpdate`, increment the `weeklyStudyTime` without resetting.
2. **Same Week but Different Day**: Maintain the weekly accumulation but update the specific day's study time. This means we don't reset the entire `weeklyStudyTime` array but update the day's entry within the week.
3. **Different Week**: Reset the `weeklyStudyTime` array since the study session crosses into a new week.
4. **Same Year but Different Month**: Update the `monthlyStudyTime` for the specific month without resetting the entire array, since it's still the same year.
5. **Different Year**: Reset the `monthlyStudyTime` array to start fresh for the new year, ensuring that monthly data is relevant to the current year only.
### Logic of Updating `todayBreaks` and `todayTimes` Fields
1. When a user chooses to end the focus session early (indicating a **break**): 
* `todayBreaks` increments by 1 if the current day is the same as `lastUpdate`; otherwise, reset to 1.
* `todayTimes` keeps the same if the current day is the same as `lastUpdate`; otherwise, reset to 0. 
* Update `lastUpdate` with the current timestamp in the end to reflect the most recent action.
3. When a user **fully completes** the focus session:
* `todayTimes` increments by 1 if the current day is the same as `lastUpdate`; otherwise, reset to 1. 
* `todayBreaks` keeps the same if the current day is the same as `lastUpdate`; otherwise, reset to 0. 
* Update `lastUpdate` with the current timestamp in the end to reflect the most recent action.