### PR TITLE
Fixed npm install warnings

### DIFF
--- a/App.jsx
+++ b/App.jsx
@@ -2,8 +2,6 @@ import { StatusBar } from "expo-status-bar";
 import AuthStackNav from "./src/components/navigation/AuthStackNav";
 import AppTabNav from "./src/components/navigation/AppTabNav";
 import { NavigationContainer } from "@react-navigation/native";
-import { GluestackUIProvider } from "@gluestack-ui/themed";
-import { config } from "@gluestack-ui/config";
 import { useEffect, useState } from "react";
 import { onAuthStateChanged } from "firebase/auth";
 import { auth } from "./src/api/FirestoreConfig";
@@ -22,13 +20,11 @@ export default function App() {
 
   return (
     <QueryClientProvider client={queryClient}>
-      <GluestackUIProvider config={config}>
-        <NavigationContainer>
-          {!isAuthed && <AuthStackNav />}
-          {isAuthed && <AppTabNav />}
-          <StatusBar style="light" />
-        </NavigationContainer>
-      </GluestackUIProvider>
+      <NavigationContainer>
+        {!isAuthed && <AuthStackNav />}
+        {isAuthed && <AppTabNav />}
+        <StatusBar style="light" />
+      </NavigationContainer>
     </QueryClientProvider>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "studysphere",
       "version": "1.0.0",
       "dependencies": {
-        "@gluestack-style/react": "^1.0.52",
-        "@gluestack-ui/config": "^1.1.18",
-        "@gluestack-ui/themed": "^1.1.17",
         "@react-native-async-storage/async-storage": "^1.22.3",
         "@react-native-community/datetimepicker": "^7.6.3",
         "@react-native-picker/picker": "^2.7.2",
@@ -38,18 +35,6 @@
       "devDependencies": {
         "@babel/core": "^7.20.0",
         "react-native-dotenv": "^3.4.11"
-      }
-    },
-    "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
-      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2661,11 +2646,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@expo/html-elements": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/@expo/html-elements/-/html-elements-0.9.1.tgz",
-      "integrity": "sha512-HOWw6tkOknG98CTTCaT3S+wRRcS00FY6v6JIc3b8LEcIxppFnNDDhxzvtdMbATzg+wQ6c2xxqfxA6FeibGNSNQ=="
-    },
     "node_modules/@expo/image-utils": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@expo/image-utils/-/image-utils-0.4.1.tgz",
@@ -3883,651 +3863,10 @@
       "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.10.5.tgz",
       "integrity": "sha512-eSkJsnhBWv5kCTSU1tSUVl9mpFu+5NXXunZc83le8GMjMlsWwQArSc7cJJ4yl+aDFY0NGLi0AjZWMn1axOrkRg=="
     },
-    "node_modules/@formatjs/ecma402-abstract": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-1.18.2.tgz",
-      "integrity": "sha512-+QoPW4csYALsQIl8GbN14igZzDbuwzcpWrku9nyMXlaqAlwRBgl5V+p0vWMGFqHOw37czNXaP/lEk4wbLgcmtA==",
-      "dependencies": {
-        "@formatjs/intl-localematcher": "0.5.4",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.0.tgz",
-      "integrity": "sha512-hnk/nY8FyrL5YxwP9e4r9dqeM6cAbo8PeU9UjyXojZMNvVad2Z06FAVHyR3Ecw6fza+0GH7vdJgiKIVXTMbSBA==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.7.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.7.6.tgz",
-      "integrity": "sha512-etVau26po9+eewJKYoiBKP6743I1br0/Ie00Pb/S/PtmYfmjTcOn2YCh2yNkSZI12h6Rg+BOgQYborXk46BvkA==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "@formatjs/icu-skeleton-parser": "1.8.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.0.tgz",
-      "integrity": "sha512-QWLAYvM0n8hv7Nq5BEs4LKIjevpVpbGLAJgOaYzg9wABEoX1j0JO1q2/jVkO6CVlq0dbsxZCngS5aXbysYueqA==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@formatjs/intl-localematcher": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.4.tgz",
-      "integrity": "sha512-zTwEpWOzZ2CiKcB93BLngUX59hQkuZjT2+SAQEscSm52peDW/getsawMcWF1rGRpMCX6D7nSJA3CzJ8gn13N/g==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw=="
-    },
-    "node_modules/@gluestack-style/animation-resolver": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@gluestack-style/animation-resolver/-/animation-resolver-1.0.4.tgz",
-      "integrity": "sha512-AeAQ61u41j9F2fxWTGiR6C7G3KG7qSCAYVi3jCE+aUiOEPEctfurUCT70DnrKp1Tg/Bl29a+OUwutaW/3YKvQw==",
-      "peerDependencies": {
-        "@gluestack-style/react": ">=1.0"
-      }
-    },
-    "node_modules/@gluestack-style/legend-motion-animation-driver": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@gluestack-style/legend-motion-animation-driver/-/legend-motion-animation-driver-1.0.3.tgz",
-      "integrity": "sha512-sD6aFS6Tq5XpyjrboFEIc8LrRY4TA4kodFYHzk6mDchvbkdLODijtjnaDQB1UqihOkMRg49e7ANRAOzc7eymaQ==",
-      "peerDependencies": {
-        "@gluestack-style/react": ">=1.0.27",
-        "@legendapp/motion": ">=2.2"
-      }
-    },
-    "node_modules/@gluestack-style/react": {
-      "version": "1.0.52",
-      "resolved": "https://registry.npmjs.org/@gluestack-style/react/-/react-1.0.52.tgz",
-      "integrity": "sha512-7i6ZGL9e++sVqqHfuRib1+wlpsZQlUAVVXa8pt9UoX2Ljl4xtXLGGs1tfvrDACAWYSNayp4dgJUVRg/XJYY9fQ==",
-      "dependencies": {
-        "inline-style-prefixer": "^6.0.1",
-        "normalize-css-color": "^1.0.2"
-      }
-    },
-    "node_modules/@gluestack-ui/accordion": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/accordion/-/accordion-1.0.1.tgz",
-      "integrity": "sha512-CLrsR4jbC3nUJifwtpiWnngi1KIeiaXCQ+D9Pm5F0wSyDTQA8e3EFSAdqAEcz/CVE8OItIiFaIDt288Un/ZQJw==",
-      "dependencies": {
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/accordion": "^0.0.2",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/actionsheet": {
-      "version": "0.2.37",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/actionsheet/-/actionsheet-0.2.37.tgz",
-      "integrity": "sha512-3X7KaIMyGCImQmz7MNQyOY7Or87NRYDjos7KF76Gla8jqapTfheB+5UNtLm6PbexjV/8B3Y8lFZhyk4+qmxvzA==",
-      "dependencies": {
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/overlay": "^0.1.12",
-        "@gluestack-ui/transitions": "^0.1.10",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/dialog": "^0.0.3",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/alert": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/alert/-/alert-0.1.12.tgz",
-      "integrity": "sha512-oiJfxryKh7+WKKx9PjIX088wgIQTXD9llC52h5HiK1dPUJiswjgGKbFHZbX7uoh9VMiXthBoUvzOIVMv0i5feA==",
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/alert-dialog": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/alert-dialog/-/alert-dialog-0.1.25.tgz",
-      "integrity": "sha512-q7bQmxCnQK4OvHqrVizNOhWh6Pdw63PVmnZ6DeUA6EQn4Jmzqw3WcWEAOWgKRXjilU2frWZIGPebFx5AeNzOSw==",
-      "dependencies": {
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/overlay": "^0.1.12",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/dialog": "^0.0.3",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/avatar": {
-      "version": "0.1.15",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/avatar/-/avatar-0.1.15.tgz",
-      "integrity": "sha512-ohbgt4FVQ3yzdZrUsEx39LSxyLUqVoj1FIapENNqmCkXqk+wwDwcyEhALInu7JOsuzPAXpUuv4b478XNsYUCTg==",
-      "dependencies": {
-        "@gluestack-ui/utils": "^0.1.12"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/button": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/button/-/button-1.0.1.tgz",
-      "integrity": "sha512-49jqhA2GIK55OGQOIFVD4P4cz+UJ/IzeBfQTmYUrbEvgJMoa8UOdWiA7FPSOJVs6b6cF6HqziLsZTycvpnlnNg==",
-      "dependencies": {
-        "@gluestack-ui/utils": "0.1.12",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/checkbox": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/checkbox/-/checkbox-0.1.24.tgz",
-      "integrity": "sha512-r1W3M6IO86YkrwTUv0bWxquM+Rpmjw0BDWehH7YMDPnyuoU5UBjGRAg8VfE3RdjIsPfLVoeUztWCLqqu6TMlmg==",
-      "dependencies": {
-        "@gluestack-ui/form-control": "^0.1.16",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-aria/visually-hidden": "^3.8.6",
-        "@react-native-aria/checkbox": "^0.2.6",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/utils": "^0.2.10",
-        "@react-stately/checkbox": "^3.4.2"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/config": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/config/-/config-1.1.18.tgz",
-      "integrity": "sha512-O7sP3cwxUNWMMBmrI7djR8M6xq1Gi5YdJuugBkJMcVwKgD8SzPbxACX20hONEMMua5hLwXPvVOzAX24WooxLkw==",
-      "peerDependencies": {
-        "@gluestack-style/react": ">=1.0",
-        "@gluestack-ui/themed": ">=1.1"
-      }
-    },
-    "node_modules/@gluestack-ui/divider": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/divider/-/divider-0.1.8.tgz",
-      "integrity": "sha512-l+OQ1XD5qI20ghxKbpi+pqntRtd0mtkmhfXYLODbjt2eec3U9kpV1xawXpfN/TFd45WWZTpEQ616sOQqFLo3RA==",
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/fab": {
-      "version": "0.1.18",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/fab/-/fab-0.1.18.tgz",
-      "integrity": "sha512-uOBTRk7C/N27WyprLtmADPL+8XF31TDEF9S/z/HM2OE2SujuoMG477MNrgrm40SAvad7jePDNv4QRcqVuGxnkA==",
-      "dependencies": {
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/form-control": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/form-control/-/form-control-0.1.16.tgz",
-      "integrity": "sha512-Yc1PaF8BElKcDUA580pdC8++4spGc36yykJblieFlkA5Hvwp5VbAB8LOI6y0KEFLChQHMXKXueUdcTvYqENDJw==",
-      "dependencies": {
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/hooks": {
-      "version": "0.1.11",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/hooks/-/hooks-0.1.11.tgz",
-      "integrity": "sha512-bcBsF7bTo//JD6L9ekJu0rZs83qYD/pE/Uj3ih3OYEtGU0LDoYiGkBMmDRpVMcVv8bE3TCKivnhHaT/heafInA==",
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/icon": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/icon/-/icon-0.1.20.tgz",
-      "integrity": "sha512-f/+DGR3139LU9NbMMvoumZWIwqy4B4e+xc02kAAubiv7p7aqGDV5KPm2JN5vVmCwiDRxX5u0F3SxodSQhEoQZA==",
-      "dependencies": {
-        "@gluestack-ui/provider": "^0.1.6",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/image": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/image/-/image-0.1.7.tgz",
-      "integrity": "sha512-ITfDX7gyxab+w0EMmJdITgG7EB2oF/3MfYgsFBV//VmIlu3OJg2xvnwvYzq3kNdGqr5Nt/5ZEG2ime7Kx2Wmxw==",
-      "dependencies": {
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/input": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/input/-/input-0.1.24.tgz",
-      "integrity": "sha512-5G/XzLzWX7d2XFqLGqN9VHUO/65JoX8kghXBrQA1V0W10NM0abAqiuz4D6mZJjWAJc57me1ob04pG1WsmELbvA==",
-      "dependencies": {
-        "@gluestack-ui/form-control": "^0.1.16",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/link": {
-      "version": "0.1.17",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/link/-/link-0.1.17.tgz",
-      "integrity": "sha512-Lzolq6LNz401qOpetMpoK2Rc/enpHucwgZtMRX4SnP9DV6vOsCAAIyBrLsCkCxN5JicdteVpPyZpoljExkACLQ==",
-      "dependencies": {
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/menu": {
-      "version": "0.2.30",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/menu/-/menu-0.2.30.tgz",
-      "integrity": "sha512-DxKnVPLinzfCLUftG3ek0yx+8FP5oF1QPDtd62YhmrL/4ybUTMQtDDsg8GIjrjL+kgUHvt0bofsQfwD897lmLg==",
-      "dependencies": {
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/overlay": "^0.1.12",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-aria/overlays": "^3.19.0",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/menu": "0.2.10",
-        "@react-native-aria/overlays": "^0.3.10",
-        "@react-stately/utils": "^3.6.0",
-        "react-stately": "^3.21.0"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/modal": {
-      "version": "0.1.29",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/modal/-/modal-0.1.29.tgz",
-      "integrity": "sha512-zPkdvUyuvWmolVtmCpgCCzLOcBuR7Xur6ugQflv4JQVN6l/NSfcBfh9mXBAUAuK2h6leo02abrURFjneXfBP+Q==",
-      "dependencies": {
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/overlay": "^0.1.12",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/dialog": "^0.0.3",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/overlays": "^0.3.10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/overlay": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/overlay/-/overlay-0.1.12.tgz",
-      "integrity": "sha512-rENETe40IRIrFW7rQKBsVotJ0J7DxTmY4xZGyMM/dct6TXnnZa2vIE+mqOK0CQs3cEIWypvDrQrJ0mHWHK1xig==",
-      "dependencies": {
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/overlays": "^0.3.10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/popover": {
-      "version": "0.1.32",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/popover/-/popover-0.1.32.tgz",
-      "integrity": "sha512-oXQMQfoARmVRjiqA2wbskfpv8FXRVBWw0MbApXcYHZGQoN1QkxM/ufqqCQdAhAM1xrI4SfrK4p9gr/hWQEVwoA==",
-      "dependencies": {
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/overlay": "^0.1.12",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/dialog": "^0.0.3",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/overlays": "^0.3.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/pressable": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/pressable/-/pressable-0.1.14.tgz",
-      "integrity": "sha512-SaGpalVO//RLpFFGibYBr+54tzcB8nUby4qBNvL2KGx+9HyMrMJFf75ov2aTqpXDrhEmtc8W4oRHd3fldvJIgw==",
-      "dependencies": {
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/progress": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/progress/-/progress-0.1.13.tgz",
-      "integrity": "sha512-M05p5UfMaBpY2pqAw5AY/rItF3Qh5mSXoJkxUQRNYbJ2UwFpvFLDXgIBpy2p6eDgOGeo7aWmsktifLztm+4uFQ==",
-      "dependencies": {
-        "@gluestack-ui/utils": "^0.1.12"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/provider": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/provider/-/provider-0.1.10.tgz",
-      "integrity": "sha512-zAfwQM3AUETLL8Br1GUAsnOdn1RhF/Acd33DawbfFSH9GS/RXtgAgt/Fkh7ANirIxCAYmg5z8G9EN+egIbyuwA==",
-      "dependencies": {
-        "@react-native-aria/interactions": "^0.2.10",
-        "tsconfig": "7",
-        "typescript": "^4.9.4"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/radio": {
-      "version": "0.1.25",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/radio/-/radio-0.1.25.tgz",
-      "integrity": "sha512-Rl/5SW6bpT0n8P38G9IWp4/T5E1Ss8+Xct9jbXOsQyowJcH5Vh4P5pZ5eLh7qC9oLMJKwQMXKc921jUNCpcPXw==",
-      "dependencies": {
-        "@gluestack-ui/form-control": "^0.1.16",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-aria/visually-hidden": "^3.7.0",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/radio": "^0.2.7",
-        "@react-stately/radio": "^3.8.1"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/range-slider": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/range-slider/-/range-slider-0.1.1.tgz",
-      "integrity": "sha512-JJ8EIMW2uczwNpahGhKwZQ0RA+CYVcvBNCgwfNZlHcNAVE0VDqlQe+wcxms4ijoq4c5zDB+YCA1AMquZe4RMOw==",
-      "dependencies": {
-        "@gluestack-ui/form-control": "^0.1.14",
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-aria/visually-hidden": "^3.8.1",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/slider": "^0.2.10",
-        "@react-stately/slider": "^3.2.4"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/react-native-aria": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/react-native-aria/-/react-native-aria-0.1.5.tgz",
-      "integrity": "sha512-6IaE4fcBaGMu3kSDKAoo1wE5qXcoKDX5YA14zzYzXN2d67/K9NYSjpoo/GbxDWZVl45X6Z9QLS/SBP7SmsPO+Q==",
-      "dependencies": {
-        "@react-native-aria/focus": "^0.2.7"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/select": {
-      "version": "0.1.24",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/select/-/select-0.1.24.tgz",
-      "integrity": "sha512-iCDH0aoGYz2ymVbn0nnjynyQ1L+mV0YFOUc16gS+DTgfjSrXdjTSYwC0vI3fAoG+Sq30il08A+Y2vuYQHTflZg==",
-      "dependencies": {
-        "@gluestack-ui/form-control": "^0.1.16",
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/slider": {
-      "version": "0.1.21",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/slider/-/slider-0.1.21.tgz",
-      "integrity": "sha512-OZlMgzLnQllXylwpAzz99Bm4XLp9IQH3R+jE3nANIPLNV9DnJUGckCIbXnoarTqUk+F+8Q0xFVb9bSLF9ujAUQ==",
-      "dependencies": {
-        "@gluestack-ui/form-control": "^0.1.16",
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-aria/visually-hidden": "^3.8.1",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/slider": "^0.2.10",
-        "@react-stately/slider": "^3.2.4"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/spinner": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/spinner/-/spinner-0.1.14.tgz",
-      "integrity": "sha512-6uLUvyJMhYR/sIMU/purfaYPqaKiLqnBi0n0LiWRsJNGDgENqdWVHMJpGTdWaFuCLxumZ7xnp0wG2KAdG9UyyQ==",
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/switch": {
-      "version": "0.1.19",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/switch/-/switch-0.1.19.tgz",
-      "integrity": "sha512-abfFqpvQOF+ZYS516FGtiabxbxYE8edMRL1uFJ3LTCCU6cQ0xikAxajAZmc9mp8AWHmNHsAmuKPxjNLY3dTSsQ==",
-      "dependencies": {
-        "@gluestack-ui/form-control": "^0.1.16",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-stately/toggle": "^3.4.4"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/tabs": {
-      "version": "0.1.14",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/tabs/-/tabs-0.1.14.tgz",
-      "integrity": "sha512-QIAf+ACVFIBm5khxMPNwo4hGtr+uOdc18ygeyHmCOQaCBAhQN9zyscDg5PjBDNasHk7I9WJf5sVr2A4ZzRXybg==",
-      "dependencies": {
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/textarea": {
-      "version": "0.1.20",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/textarea/-/textarea-0.1.20.tgz",
-      "integrity": "sha512-BkpOwyGT2I12elofVzEs4YbFAxPc41CqUpNc6wNEyovLjPs6BuVzZ7b0U/0xf8C72kj3h5s02GWrkHHVd+Lztw==",
-      "dependencies": {
-        "@gluestack-ui/form-control": "^0.1.16",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/themed": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/themed/-/themed-1.1.17.tgz",
-      "integrity": "sha512-TIFCxWH4jjo31qWRTmijsG6rBClAZ9r8oolQGKOVfdEC9/SNIbRNFlyqnVWmOpLf4XnhKp1XNkiD6rtf4VEO5Q==",
-      "dependencies": {
-        "@expo/html-elements": "latest",
-        "@gluestack-style/animation-resolver": "1.0.4",
-        "@gluestack-style/legend-motion-animation-driver": "1.0.3",
-        "@gluestack-ui/accordion": "1.0.1",
-        "@gluestack-ui/actionsheet": "0.2.37",
-        "@gluestack-ui/alert": "0.1.12",
-        "@gluestack-ui/alert-dialog": "0.1.25",
-        "@gluestack-ui/avatar": "0.1.15",
-        "@gluestack-ui/button": "1.0.1",
-        "@gluestack-ui/checkbox": "0.1.24",
-        "@gluestack-ui/divider": "0.1.8",
-        "@gluestack-ui/fab": "0.1.18",
-        "@gluestack-ui/form-control": "0.1.16",
-        "@gluestack-ui/icon": "0.1.20",
-        "@gluestack-ui/image": "0.1.7",
-        "@gluestack-ui/input": "0.1.24",
-        "@gluestack-ui/link": "0.1.17",
-        "@gluestack-ui/menu": "0.2.30",
-        "@gluestack-ui/modal": "0.1.29",
-        "@gluestack-ui/overlay": "0.1.12",
-        "@gluestack-ui/popover": "0.1.32",
-        "@gluestack-ui/pressable": "0.1.14",
-        "@gluestack-ui/progress": "0.1.13",
-        "@gluestack-ui/provider": "0.1.10",
-        "@gluestack-ui/radio": "0.1.25",
-        "@gluestack-ui/range-slider": "0.1.1",
-        "@gluestack-ui/select": "0.1.24",
-        "@gluestack-ui/slider": "0.1.21",
-        "@gluestack-ui/spinner": "0.1.14",
-        "@gluestack-ui/switch": "0.1.19",
-        "@gluestack-ui/tabs": "0.1.14",
-        "@gluestack-ui/textarea": "0.1.20",
-        "@gluestack-ui/toast": "1.0.4",
-        "@gluestack-ui/tooltip": "0.1.26",
-        "@legendapp/motion": "latest"
-      },
-      "peerDependencies": {
-        "@gluestack-style/react": ">=1.0",
-        "@types/react-native": ">=0.72",
-        "react": ">=16",
-        "react-dom": ">=16",
-        "react-native": ">=0.72",
-        "react-native-svg": ">=13.4.0",
-        "react-native-web": ">=0.19"
-      }
-    },
-    "node_modules/@gluestack-ui/toast": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/toast/-/toast-1.0.4.tgz",
-      "integrity": "sha512-GVEESsSl567OR/0JlVTuivK6G1EgfEC7N+CAuH6lx+s87qXcOMXeFAgltp6Mxl8g0g5hTPLWrDts2qQLzqwFOA==",
-      "dependencies": {
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/overlay": "^0.1.12",
-        "@gluestack-ui/transitions": "^0.1.10",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/tooltip": {
-      "version": "0.1.26",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/tooltip/-/tooltip-0.1.26.tgz",
-      "integrity": "sha512-3QHLV4T3Thfo7pkjmZzS051jf4pVguiR28kpCoj7/vsBxnFo3jT6VNv7cVUy9rVvB2lh1EKZyb33THB0DmEeeg==",
-      "dependencies": {
-        "@gluestack-ui/hooks": "0.1.11",
-        "@gluestack-ui/overlay": "^0.1.12",
-        "@gluestack-ui/utils": "^0.1.12",
-        "@react-native-aria/focus": "^0.2.9",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/overlays": "^0.3.10"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/transitions": {
-      "version": "0.1.10",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/transitions/-/transitions-0.1.10.tgz",
-      "integrity": "sha512-oOwYAmbebAowDCDZyRdGwhK2of46b642OZQxBBkln/BX7YEvY4PhQIfup0HUCG9YA5IzlQnw0iwqREbaVNKIgA==",
-      "dependencies": {
-        "@gluestack-ui/overlay": "^0.1.7",
-        "@gluestack-ui/react-native-aria": "^0.1.5",
-        "@gluestack-ui/utils": "^0.1.9",
-        "@react-native-aria/focus": "^0.2.7"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
-    },
-    "node_modules/@gluestack-ui/utils": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/@gluestack-ui/utils/-/utils-0.1.12.tgz",
-      "integrity": "sha512-OhOkljhr7foCUJP//8LwMN3EX4/pniFWmQpk1yDJMQL9DaTJbP7s3HsnTM7UzH2kp9DR1Utoz9Y9WscH3ajLpQ==",
-      "dependencies": {
-        "@react-native-aria/focus": "^0.2.9"
-      },
-      "peerDependencies": {
-        "react": ">=16",
-        "react-dom": ">=16"
-      }
     },
     "node_modules/@graphql-typed-document-node/core": {
       "version": "3.2.0",
@@ -4577,39 +3916,6 @@
       "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
       "dependencies": {
         "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@internationalized/date": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/date/-/date-3.5.2.tgz",
-      "integrity": "sha512-vo1yOMUt2hzp63IutEaTUxROdvQg1qlMRsbCvbay2AK2Gai7wIgCyK5weEX3nHkiLgo4qCXHijFNC/ILhlRpOQ==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@internationalized/message": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@internationalized/message/-/message-3.1.2.tgz",
-      "integrity": "sha512-MHAWsZWz8jf6jFPZqpTudcCM361YMtPIRu9CXkYmKjJ/0R3pQRScV5C0zS+Qi50O5UAm8ecKhkXx6mWDDcF6/g==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0",
-        "intl-messageformat": "^10.1.0"
-      }
-    },
-    "node_modules/@internationalized/number": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/number/-/number-3.5.1.tgz",
-      "integrity": "sha512-N0fPU/nz15SwR9IbfJ5xaS9Ss/O5h1sVXMZf43vc9mxEG48ovglvvzBjF53aHlq20uoR6c+88CrIXipU/LSzwg==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      }
-    },
-    "node_modules/@internationalized/string": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@internationalized/string/-/string-3.2.1.tgz",
-      "integrity": "sha512-vWQOvRIauvFMzOO+h7QrdsJmtN1AXAFVcaLWP9AseRN2o7iHceZ6bIXhBD4teZl8i91A3gxKnWBlGgjCwU6MFQ==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
       }
     },
     "node_modules/@isaacs/ttlcache": {
@@ -4804,32 +4110,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@legendapp/motion": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@legendapp/motion/-/motion-2.3.0.tgz",
-      "integrity": "sha512-LtTD06eyz/Ge23FAR6BY+i9Gsgr/ZgxE12FneML8LrZGcZOSPN2Ojz3N2eJaTiA50kqoeqrGCaYJja8KgKpL6Q==",
-      "dependencies": {
-        "@legendapp/tools": "2.0.1"
-      },
-      "peerDependencies": {
-        "nativewind": "^2.0.0",
-        "react": ">=16",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@legendapp/tools": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@legendapp/tools/-/tools-2.0.1.tgz",
-      "integrity": "sha512-Kxt0HWvWElRK6oybHRzcYxdgaKGwuaiRNreS7usW7QuHXRIHaH4yMcW2YNRG4DHE5fpefv+Bno/BohQcCE4FaA==",
-      "peerDependencies": {
-        "react": ">=16"
-      },
-      "peerDependenciesMeta": {
-        "react": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -4992,448 +4272,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.0.tgz",
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw=="
-    },
-    "node_modules/@react-aria/dialog": {
-      "version": "3.5.12",
-      "resolved": "https://registry.npmjs.org/@react-aria/dialog/-/dialog-3.5.12.tgz",
-      "integrity": "sha512-7UJR/h/Y364u6Ltpw0bT51B48FybTuIBacGpEJN5IxZlpxvQt0KQcBDiOWfAa/GQogw4B5hH6agaOO0nJcP49Q==",
-      "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/overlays": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/dialog": "^3.5.8",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/focus": {
-      "version": "3.16.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/focus/-/focus-3.16.2.tgz",
-      "integrity": "sha512-Rqo9ummmgotESfypzFjI3uh58yMpL+E+lJBbQuXkBM0u0cU2YYzu0uOrFrq3zcHk997udZvq1pGK/R+2xk9B7g==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/form": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/@react-aria/form/-/form-3.0.3.tgz",
-      "integrity": "sha512-5Q2BHE4TTPDzGY2npCzpRRYshwWUb3SMUA/Cbz7QfEtBk+NYuVaq3KjvqLqgUUdyKtqLZ9Far0kIAexloOC4jw==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/form": "^3.0.1",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/i18n": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/i18n/-/i18n-3.10.2.tgz",
-      "integrity": "sha512-Z1ormoIvMOI4mEdcFLYsoJy9w/EzBdBmgfLP+S/Ah+1xwQOXpgwZxiKOhYHpWa0lf6hkKJL34N9MHJvCJ5Crvw==",
-      "dependencies": {
-        "@internationalized/date": "^3.5.2",
-        "@internationalized/message": "^3.1.2",
-        "@internationalized/number": "^3.5.1",
-        "@internationalized/string": "^3.2.1",
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/interactions": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/interactions/-/interactions-3.21.1.tgz",
-      "integrity": "sha512-AlHf5SOzsShkHfV8GLLk3v9lEmYqYHURKcXWue0JdYbmquMRkUsf/+Tjl1+zHVAQ8lKqRnPYbTmc4AcZbqxltw==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/label": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/@react-aria/label/-/label-3.7.6.tgz",
-      "integrity": "sha512-ap9iFS+6RUOqeW/F2JoNpERqMn1PvVIo3tTMrJ1TY1tIwyJOxdCBRgx9yjnPBnr+Ywguep+fkPNNi/m74+tXVQ==",
-      "dependencies": {
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/menu": {
-      "version": "3.13.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/menu/-/menu-3.13.1.tgz",
-      "integrity": "sha512-jF80YIcvD16Fgwm5pj7ViUE3Dj7z5iewQixLaFVdvpgfyE58SD/ZVU9/JkK5g/03DYM0sjpUKZGkdFxxw8eKnw==",
-      "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/overlays": "^3.21.1",
-        "@react-aria/selection": "^3.17.5",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/menu": "^3.6.1",
-        "@react-stately/tree": "^3.7.6",
-        "@react-types/button": "^3.9.2",
-        "@react-types/menu": "^3.9.7",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/overlays": {
-      "version": "3.21.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/overlays/-/overlays-3.21.1.tgz",
-      "integrity": "sha512-djEBDF+TbIIOHWWNpdm19+z8xtY8U+T+wKVQg/UZ6oWnclSqSWeGl70vu73Cg4HVBJ4hKf1SRx4Z/RN6VvH4Yw==",
-      "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/ssr": "^3.9.2",
-        "@react-aria/utils": "^3.23.2",
-        "@react-aria/visually-hidden": "^3.8.10",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/button": "^3.9.2",
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/radio": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/radio/-/radio-3.10.2.tgz",
-      "integrity": "sha512-CTUTR+qt3BLjmyQvKHZuVm+1kyvT72ZptOty++sowKXgJApTLdjq8so1IpaLAr8JIfzqD5I4tovsYwIQOX8log==",
-      "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/form": "^3.0.3",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/label": "^3.7.6",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/radio": "^3.10.2",
-        "@react-types/radio": "^3.7.1",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/selection": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/@react-aria/selection/-/selection-3.17.5.tgz",
-      "integrity": "sha512-gO5jBUkc7WdkiFMlWt3x9pTSuj3Yeegsxfo44qU5NPlKrnGtPRZDWrlACNgkDHu645RNNPhlyoX0C+G8mUg1xA==",
-      "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/selection": "^3.14.3",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/slider": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/@react-aria/slider/-/slider-3.7.6.tgz",
-      "integrity": "sha512-ZeZhyHzhk9gxGuThPKgX2K3RKsxPxsFig1iYoJvqP8485NtHYQIPht2YcpEKA9siLxGF0DR9VCfouVhSoW0AEA==",
-      "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/i18n": "^3.10.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/label": "^3.7.6",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/slider": "^3.5.2",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/slider": "^3.7.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/ssr": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/ssr/-/ssr-3.9.2.tgz",
-      "integrity": "sha512-0gKkgDYdnq1w+ey8KzG9l+H5Z821qh9vVjztk55rUg71vTk/Eaebeir+WtzcLLwTjw3m/asIjx8Y59y1lJZhBw==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 12"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/toggle": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/toggle/-/toggle-3.10.2.tgz",
-      "integrity": "sha512-DgitscHWgI6IFgnvp2HcMpLGX/cAn+XX9kF5RJQbRQ9NqUgruU5cEEGSOLMrEJ6zXDa2xmOiQ+kINcyNhA+JLg==",
-      "dependencies": {
-        "@react-aria/focus": "^3.16.2",
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-stately/toggle": "^3.7.2",
-        "@react-types/checkbox": "^3.7.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/utils": {
-      "version": "3.23.2",
-      "resolved": "https://registry.npmjs.org/@react-aria/utils/-/utils-3.23.2.tgz",
-      "integrity": "sha512-yznR9jJ0GG+YJvTMZxijQwVp+ahP66DY0apZf7X+dllyN+ByEDW+yaL1ewYPIpugxVzH5P8jhnBXsIyHKN411g==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.9.2",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0",
-        "clsx": "^2.0.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-aria/visually-hidden": {
-      "version": "3.8.10",
-      "resolved": "https://registry.npmjs.org/@react-aria/visually-hidden/-/visually-hidden-3.8.10.tgz",
-      "integrity": "sha512-np8c4wxdbE7ZrMv/bnjwEfpX0/nkWy9sELEb0sK8n4+HJ+WycoXXrVxBUb9tXgL/GCx5ReeDQChjQWwajm/z3A==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.21.1",
-        "@react-aria/utils": "^3.23.2",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-native-aria/accordion": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/accordion/-/accordion-0.0.2.tgz",
-      "integrity": "sha512-2Wa/YDBc2aCunTLpqwxTfCwn1t63KSAIoXd0hqrUGJJF+N2bEs2Hqs9ZgyKJ/hzFxCknVPMqo0fEVE1H23Z5+g==",
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/checkbox": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/checkbox/-/checkbox-0.2.9.tgz",
-      "integrity": "sha512-REycBw1DKbw2r9LbynrB+egWOnJXo1YPoMkAQOv6wiKgIzRZ69l4GpmAwkwqUmKit+DJM9Van6/cGl9kOKTAeA==",
-      "dependencies": {
-        "@react-aria/checkbox": "3.2.1",
-        "@react-aria/utils": "^3.6.0",
-        "@react-native-aria/toggle": "^0.2.8",
-        "@react-native-aria/utils": "0.2.11",
-        "@react-stately/toggle": "^3.2.1"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/checkbox/node_modules/@react-aria/checkbox": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@react-aria/checkbox/-/checkbox-3.2.1.tgz",
-      "integrity": "sha512-XnypnlVIfhB3CD7eSjSds8hNkzHgnhu0t48I1D0jYdL1O6tQC4UytPdIqlemRYBVHDloZkWerbjenpHnxhv8iA==",
-      "dependencies": {
-        "@babel/runtime": "^7.6.2",
-        "@react-aria/label": "^3.1.1",
-        "@react-aria/toggle": "^3.1.1",
-        "@react-aria/utils": "^3.3.0",
-        "@react-stately/checkbox": "^3.0.1",
-        "@react-stately/toggle": "^3.2.1",
-        "@react-types/checkbox": "^3.2.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1"
-      }
-    },
-    "node_modules/@react-native-aria/dialog": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/dialog/-/dialog-0.0.3.tgz",
-      "integrity": "sha512-EXDS2IfB6n8LlelfMZjMntuHC7e6iRTWLxrYIyHm5d2gdmRVD37dris03Zsw/iMBhb/Z8ZYKQ/O5APioN6Uovg==",
-      "dependencies": {
-        "@react-aria/dialog": "*",
-        "@react-native-aria/utils": "*",
-        "@react-types/dialog": "*",
-        "@react-types/shared": "*"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/focus": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/focus/-/focus-0.2.9.tgz",
-      "integrity": "sha512-zVgOIzKwnsyyurUxlZnzUKB2ekK/cmK64sQJIKKUlkJKVxd2EAFf7Sjz/NVEoMhTODN3qGRASTv9bMk/pBzzVA==",
-      "dependencies": {
-        "@react-aria/focus": "^3.2.3"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/interactions": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/interactions/-/interactions-0.2.13.tgz",
-      "integrity": "sha512-Uzru5Pqq5pG46lg/pzXoku9Y9k1UvuwJB/HRLSwahdC6eyNJOOm4kmadR/iziL/BeTAi5rOZsPEd0IKcMdH3nA==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.3.2",
-        "@react-aria/utils": "^3.6.0",
-        "@react-native-aria/utils": "0.2.11"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/menu": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/menu/-/menu-0.2.10.tgz",
-      "integrity": "sha512-oQeArGeN91zpmA4aXX2eNLQLOJBb1fm5YiFtcmZAVp1rC7yZp1ys/RWX4AHEHhOsd148+sZnQ8B0fxcxV/bOoQ==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.3.2",
-        "@react-aria/menu": "^3.1.3",
-        "@react-aria/selection": "^3.3.1",
-        "@react-aria/utils": "^3.6.0",
-        "@react-native-aria/interactions": "^0.2.11",
-        "@react-native-aria/overlays": "^0.3.10",
-        "@react-native-aria/utils": "^0.2.10",
-        "@react-stately/collections": "^3.3.0",
-        "@react-stately/menu": "^3.2.1",
-        "@react-stately/tree": "^3.1.2",
-        "@react-types/menu": "^3.1.1"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/overlays": {
-      "version": "0.3.12",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/overlays/-/overlays-0.3.12.tgz",
-      "integrity": "sha512-XV/JjL+zimkpDT7WfomrZl6D7on2RFnhlM0/EPwCPoHRALrJf1gcyEtl0ubWpB3b9yg5uliJ8u0zOS9ui/8S/Q==",
-      "dependencies": {
-        "@react-aria/interactions": "^3.3.2",
-        "@react-aria/overlays": "^3.7.0",
-        "@react-native-aria/utils": "0.2.11",
-        "@react-stately/overlays": "^3.1.1",
-        "@react-types/overlays": "^3.4.0",
-        "dom-helpers": "^5.0.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-dom": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/radio": {
-      "version": "0.2.10",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/radio/-/radio-0.2.10.tgz",
-      "integrity": "sha512-q6oe/cMPKJDDaE11J8qBfAgn3tLRh1OFYCPDVIOXkGGm/hjEQNCR+E46kX9yQ+oD2ajf0WV/toxG3RqWAiKZ6Q==",
-      "dependencies": {
-        "@react-aria/radio": "^3.1.2",
-        "@react-aria/utils": "^3.6.0",
-        "@react-native-aria/interactions": "0.2.13",
-        "@react-native-aria/utils": "0.2.11",
-        "@react-stately/radio": "^3.2.1",
-        "@react-types/radio": "^3.1.1"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/slider": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/slider/-/slider-0.2.11.tgz",
-      "integrity": "sha512-GVT0VOEosf7jk5B6nU0stxitnHbAWLjmarOgkun0/Nnkc0/RwRaf+hfdPGA8rZqNS01CIgooJSrxfIfyNgybpg==",
-      "dependencies": {
-        "@react-aria/focus": "^3.2.3",
-        "@react-aria/interactions": "^3.3.2",
-        "@react-aria/label": "^3.1.1",
-        "@react-aria/slider": "^3.0.1",
-        "@react-aria/utils": "^3.6.0",
-        "@react-native-aria/utils": "0.2.11",
-        "@react-stately/slider": "^3.0.1"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/toggle": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/toggle/-/toggle-0.2.8.tgz",
-      "integrity": "sha512-4TJXuIUuVeozbV3Lk9YUxHxCHAhignn6/GfEdQv8XsfKHUmRMHyvXwdrmKTQCnbtz2Nn+NDUoqKUfZtOYpT3cg==",
-      "dependencies": {
-        "@react-aria/focus": "^3.2.3",
-        "@react-aria/utils": "^3.6.0",
-        "@react-native-aria/interactions": "0.2.13",
-        "@react-native-aria/utils": "0.2.11",
-        "@react-stately/toggle": "^3.2.1",
-        "@react-types/checkbox": "^3.2.1"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
-    },
-    "node_modules/@react-native-aria/utils": {
-      "version": "0.2.11",
-      "resolved": "https://registry.npmjs.org/@react-native-aria/utils/-/utils-0.2.11.tgz",
-      "integrity": "sha512-8MzE25pYDo1ZQtu7N9grx2Q+2uK58Tvvg4iJ7Nvx3PXTEz2XKU8G//yX9un97f7zCM6ptL8viRdKbSYDBmQvsA==",
-      "dependencies": {
-        "@react-aria/ssr": "^3.0.1",
-        "@react-aria/utils": "^3.3.0"
-      },
-      "peerDependencies": {
-        "react": "*",
-        "react-native": "*"
-      }
     },
     "node_modules/@react-native-async-storage/async-storage": {
       "version": "1.22.3",
@@ -7766,583 +6604,6 @@
         "nanoid": "^3.1.23"
       }
     },
-    "node_modules/@react-stately/calendar": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@react-stately/calendar/-/calendar-3.4.4.tgz",
-      "integrity": "sha512-f9ZOd096gGGD+3LmU1gkmfqytGyQtrgi+Qjn+70GbM2Jy65pwOR4I9YrobbmeAFov5Tff13mQEa0yqWvbcDLZQ==",
-      "dependencies": {
-        "@internationalized/date": "^3.5.2",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/calendar": "^3.4.4",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/checkbox": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/@react-stately/checkbox/-/checkbox-3.6.3.tgz",
-      "integrity": "sha512-hWp0GXVbMI4sS2NbBjWgOnHNrRqSV4jeftP8zc5JsIYRmrWBUZitxluB34QuVPzrBO29bGsF0GTArSiQZt6BWw==",
-      "dependencies": {
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/checkbox": "^3.7.1",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/collections": {
-      "version": "3.10.5",
-      "resolved": "https://registry.npmjs.org/@react-stately/collections/-/collections-3.10.5.tgz",
-      "integrity": "sha512-k8Q29Nnvb7iAia1QvTanZsrWP2aqVNBy/1SlE6kLL6vDqtKZC+Esd1SDLHRmIcYIp5aTdfwIGd0NuiRQA7a81Q==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/combobox": {
-      "version": "3.8.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/combobox/-/combobox-3.8.2.tgz",
-      "integrity": "sha512-f+IHuFW848VoMbvTfSakn2WIh2urDxO355LrKxnisXPCkpQHpq3lvT2mJtKJwkPxjAy7xPjpV8ejgga2R6p53Q==",
-      "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/list": "^3.10.3",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-stately/select": "^3.6.2",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/combobox": "^3.10.1",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/data": {
-      "version": "3.11.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/data/-/data-3.11.2.tgz",
-      "integrity": "sha512-yhK2upk2WbJeiLBRWHrh/4G2CvmmozCzoivLaRAPYu53m1J3MyzVGCLJgnZMbMZvAbNcYWZK6IzO6VqZ2y1fOw==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/datepicker": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/datepicker/-/datepicker-3.9.2.tgz",
-      "integrity": "sha512-Z6FrK6Af7R5BizqHhJFCj3Hn32mg5iLSDdEgFQAuO043guOXUKFUAnbxfbQUjL6PGE6QwWMfQD7PPGebHn9Ifw==",
-      "dependencies": {
-        "@internationalized/date": "^3.5.2",
-        "@internationalized/string": "^3.2.1",
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/datepicker": "^3.7.2",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/dnd": {
-      "version": "3.2.8",
-      "resolved": "https://registry.npmjs.org/@react-stately/dnd/-/dnd-3.2.8.tgz",
-      "integrity": "sha512-oSo+2Bzum3Q1/d+3FuaDmpVHqqBB004tycuQDDFtad3N1BKm+fNfmslRK1ioLkPLK4sm1130V+BZBY3JXLe80A==",
-      "dependencies": {
-        "@react-stately/selection": "^3.14.3",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/flags": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/flags/-/flags-3.0.1.tgz",
-      "integrity": "sha512-h5PcDMj54aipQNO18ig/IMI1kzPwcvSwVq5M6Ib6XE1WIkOH0dIuW2eADdAOhcGi3KXJtXVdD29zh0Eox1TKgQ==",
-      "dependencies": {
-        "@swc/helpers": "^0.4.14"
-      }
-    },
-    "node_modules/@react-stately/flags/node_modules/@swc/helpers": {
-      "version": "0.4.36",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.36.tgz",
-      "integrity": "sha512-5lxnyLEYFskErRPenYItLRSge5DjrJngYKdVjRSrWfza9G6KkgHEXi0vUZiyUeMU5JfXH1YnvXZzSp8ul88o2Q==",
-      "dependencies": {
-        "legacy-swc-helpers": "npm:@swc/helpers@=0.4.14",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@react-stately/form": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/form/-/form-3.0.1.tgz",
-      "integrity": "sha512-T1Ul2Ou0uE/S4ECLcGKa0OfXjffdjEHfUFZAk7OZl0Mqq/F7dl5WpoLWJ4d4IyvZzGO6anFNenP+vODWbrF3NA==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/grid": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@react-stately/grid/-/grid-3.8.5.tgz",
-      "integrity": "sha512-KCzi0x0p1ZKK+OptonvJqMbn6Vlgo6GfOIlgcDd0dNYDP8TJ+3QFJAFre5mCr7Fubx7LcAOio4Rij0l/R8fkXQ==",
-      "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/selection": "^3.14.3",
-        "@react-types/grid": "^3.2.4",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/list": {
-      "version": "3.10.3",
-      "resolved": "https://registry.npmjs.org/@react-stately/list/-/list-3.10.3.tgz",
-      "integrity": "sha512-Ul8el0tQy2Ucl3qMQ0fiqdJ874W1ZNjURVSgSxN+pGwVLNBVRjd6Fl7YwZFCXER2YOlzkwg+Zqozf/ZlS0EdXA==",
-      "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/selection": "^3.14.3",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/menu": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/menu/-/menu-3.6.1.tgz",
-      "integrity": "sha512-3v0vkTm/kInuuG8jG7jbxXDBnMQcoDZKWvYsBQq7+POt0LmijbLdbdZPBoz9TkZ3eo/OoP194LLHOaFTQyHhlw==",
-      "dependencies": {
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/menu": "^3.9.7",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/numberfield": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/numberfield/-/numberfield-3.9.1.tgz",
-      "integrity": "sha512-btBIcBEfSVCUm6NwJrMrMygoIu/fQGazzD0RhF7PNsfvkFiWn+TSOyQqSXcsUJVOnBfoS/dVWj6r57KA7zl3FA==",
-      "dependencies": {
-        "@internationalized/number": "^3.5.1",
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/numberfield": "^3.8.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/overlays": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/@react-stately/overlays/-/overlays-3.6.5.tgz",
-      "integrity": "sha512-U4rCFj6TPJPXLUvYXAcvh+yP/CO2W+7f0IuqP7ZZGE+Osk9qFkT+zRK5/6ayhBDFpmueNfjIEAzT9gYPQwNHFw==",
-      "dependencies": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/overlays": "^3.8.5",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/radio": {
-      "version": "3.10.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/radio/-/radio-3.10.2.tgz",
-      "integrity": "sha512-JW5ZWiNMKcZvMTsuPeWJQLHXD5rlqy7Qk6fwUx/ZgeibvMBW/NnW19mm2+IMinzmbtERXvR6nsiA837qI+4dew==",
-      "dependencies": {
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/radio": "^3.7.1",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/searchfield": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/searchfield/-/searchfield-3.5.1.tgz",
-      "integrity": "sha512-9A8Wghx1avRHhMpNH1Nj+jFfiF1bhsff2GEC5PZgWYzhCykw3G5bywn3JAuUS4kh7Vpqhbu4KpHAhmWPSv4B/Q==",
-      "dependencies": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/searchfield": "^3.5.3",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/select": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/select/-/select-3.6.2.tgz",
-      "integrity": "sha512-duOxdHKol93h6Ew6fap6Amz+zngoERKZLSKVm/8I8uaBgkoBhEeTFv7mlpHTgINxymMw3mMrvy6GL/gfKFwkqg==",
-      "dependencies": {
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/list": "^3.10.3",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/select": "^3.9.2",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/selection": {
-      "version": "3.14.3",
-      "resolved": "https://registry.npmjs.org/@react-stately/selection/-/selection-3.14.3.tgz",
-      "integrity": "sha512-d/t0rIWieqQ7wjLoMoWnuHEUSMoVXxkPBFuSlJF3F16289FiQ+b8aeKFDzFTYN7fFD8rkZTnpuE4Tcxg3TmA+w==",
-      "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/slider": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/slider/-/slider-3.5.2.tgz",
-      "integrity": "sha512-ntH3NLRG+AwVC7q4Dx9DcmMkMh9vmHjHNXAgaoqNjhvwfSIae7sQ69CkVe6XeJjIBy6LlH81Kgapz+ABe5a1ZA==",
-      "dependencies": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/slider": "^3.7.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/table": {
-      "version": "3.11.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/table/-/table-3.11.6.tgz",
-      "integrity": "sha512-34YsfOILXusj3p6QNcKEaDWVORhM6WEhwPSLCZlkwAJvkxuRQFdih5rQKoIDc0uV5aZsB6bYBqiFhnjY0VERhw==",
-      "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/flags": "^3.0.1",
-        "@react-stately/grid": "^3.8.5",
-        "@react-stately/selection": "^3.14.3",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/grid": "^3.2.4",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/table": "^3.9.3",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/tabs": {
-      "version": "3.6.4",
-      "resolved": "https://registry.npmjs.org/@react-stately/tabs/-/tabs-3.6.4.tgz",
-      "integrity": "sha512-WZJgMBqzLgN88RN8AxhY4aH1+I+4w1qQA0Lh3LRSDegaytd+NHixCWaP3IPjePgCB5N1UsPe96Xglw75zjHmDg==",
-      "dependencies": {
-        "@react-stately/list": "^3.10.3",
-        "@react-types/shared": "^3.22.1",
-        "@react-types/tabs": "^3.3.5",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/toggle": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@react-stately/toggle/-/toggle-3.7.2.tgz",
-      "integrity": "sha512-SHCF2btcoK57c4lyhucRbyPBAFpp0Pdp0vcPdn3hUgqbu6e5gE0CwG/mgFmZRAQoc7PRc7XifL0uNw8diJJI0Q==",
-      "dependencies": {
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/checkbox": "^3.7.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/tooltip": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@react-stately/tooltip/-/tooltip-3.4.7.tgz",
-      "integrity": "sha512-ACtRgBQ8rphBtsUaaxvEAM0HHN9PvMuyvL0vUHd7jvBDCVZJ6it1BKu9SBKjekBkoBOw9nemtkplh9R2CA6V8Q==",
-      "dependencies": {
-        "@react-stately/overlays": "^3.6.5",
-        "@react-types/tooltip": "^3.4.7",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/tree": {
-      "version": "3.7.6",
-      "resolved": "https://registry.npmjs.org/@react-stately/tree/-/tree-3.7.6.tgz",
-      "integrity": "sha512-y8KvEoZX6+YvqjNCVGS3zA/BKw4D3XrUtUKIDme3gu5Mn6z97u+hUXKdXVCniZR7yvV3fHAIXwE5V2K8Oit4aw==",
-      "dependencies": {
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/selection": "^3.14.3",
-        "@react-stately/utils": "^3.9.1",
-        "@react-types/shared": "^3.22.1",
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-stately/utils": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@react-stately/utils/-/utils-3.9.1.tgz",
-      "integrity": "sha512-yzw75GE0iUWiyps02BOAPTrybcsMIxEJlzXqtvllAb01O9uX5n0i3X+u2eCpj2UoDF4zS08Ps0jPgWxg8xEYtA==",
-      "dependencies": {
-        "@swc/helpers": "^0.5.0"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/button": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-types/button/-/button-3.9.2.tgz",
-      "integrity": "sha512-EnPTkGHZRtiwAoJy5q9lDjoG30bEzA/qnvKG29VVXKYAGeqY2IlFs1ypmU+z1X/CpJgPcG3I5cakM7yTVm3pSg==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/calendar": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/@react-types/calendar/-/calendar-3.4.4.tgz",
-      "integrity": "sha512-hV1Thmb/AES5OmfPvvmyjSkmsEULjiDfA7Yyy70L/YKuSNKb7Su+Bf2VnZuDW3ec+GxO4JJNlpJ0AkbphWBvcg==",
-      "dependencies": {
-        "@internationalized/date": "^3.5.2",
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/checkbox": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-types/checkbox/-/checkbox-3.7.1.tgz",
-      "integrity": "sha512-kuGqjQFex0As/3gfWyk+e9njCcad/ZdnYLLiNvhlk15730xfa0MmnOdpqo9jfuFSXBjOcpxoofvEhvrRMtEdUA==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/combobox": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@react-types/combobox/-/combobox-3.10.1.tgz",
-      "integrity": "sha512-XMno1rgVRNta49vf5nV7VJpVSVAV20tt79t618gG1qRKH5Kt2Cy8lz2fQ5vHG6UTv/6jUOvU8g5Pc93sLaTmoA==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/datepicker": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/@react-types/datepicker/-/datepicker-3.7.2.tgz",
-      "integrity": "sha512-zThqFAdhQL1dqyVDsDSSTdfCjoD6634eyg/B0ZJfQxcLUR/5pch3v/gxBhbyCVDGMNHRWUWIJvY9DVOepuoSug==",
-      "dependencies": {
-        "@internationalized/date": "^3.5.2",
-        "@react-types/calendar": "^3.4.4",
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/dialog": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/@react-types/dialog/-/dialog-3.5.8.tgz",
-      "integrity": "sha512-RX8JsMvty8ADHRqVEkppoynXLtN4IzUh8d5z88UEBbcvWKlHfd6bOBQjQcBH3AUue5wjfpPIt6brw2VzgBY/3Q==",
-      "dependencies": {
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/grid": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@react-types/grid/-/grid-3.2.4.tgz",
-      "integrity": "sha512-sDVoyQcH7MoGdx5nBi5ZOU/mVFBt9YTxhvr0PZ97dMdEHZtJC1w9SuezwWS34f50yb8YAXQRTICbZYcK4bAlDA==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/menu": {
-      "version": "3.9.7",
-      "resolved": "https://registry.npmjs.org/@react-types/menu/-/menu-3.9.7.tgz",
-      "integrity": "sha512-K6KhloJVoGsqwkdeez72fkNI9dfrmLI/sNrB4XuOKo2crDQ/eyZYWyJmzz8giz/tHME9w774k487rVoefoFh5w==",
-      "dependencies": {
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/numberfield": {
-      "version": "3.8.1",
-      "resolved": "https://registry.npmjs.org/@react-types/numberfield/-/numberfield-3.8.1.tgz",
-      "integrity": "sha512-GaCjLQgXUGCt40SLjKk3/COMWFlN2vV/3Xs3VSLAEdFZpk99b+Ik1oR21+7ZP5/iMHuQDc1MJRWdFfIjxCvVDQ==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/overlays": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@react-types/overlays/-/overlays-3.8.5.tgz",
-      "integrity": "sha512-4D7EEBQigD/m8hE68Ys8eloyyZFHHduqykSIgINJ0edmo0jygRbWlTwuhWFR9USgSP4dK54duN0Mvq0m4HEVEw==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/radio": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-types/radio/-/radio-3.7.1.tgz",
-      "integrity": "sha512-Zut3rN1odIUBLZdijeyou+UqsLeRE76d9A+npykYGu29ndqmo3w4sLn8QeQcdj1IR71ZnG0pW2Y2BazhK5XrrQ==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/searchfield": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/@react-types/searchfield/-/searchfield-3.5.3.tgz",
-      "integrity": "sha512-gBfsT1WpY8UIb74yyYmnjiHpVasph2mdmGj9i8cGF2HUYwx5p+Fr85mtCGDph0uirvRoM5ExMp4snD+ueNAVCg==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1",
-        "@react-types/textfield": "^3.9.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/select": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@react-types/select/-/select-3.9.2.tgz",
-      "integrity": "sha512-fGFrunednY3Pq/BBwVOf87Fsuyo/SlevL0wFIE9OOl2V5NXVaTY7/7RYA8hIOHPzmvsMbndy419BEudiNGhv4A==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/shared": {
-      "version": "3.22.1",
-      "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.22.1.tgz",
-      "integrity": "sha512-PCpa+Vo6BKnRMuOEzy5zAZ3/H5tnQg1e80khMhK2xys0j6ZqzkgQC+fHMNZ7VDFNLqqNMj/o0eVeSBDh2POjkw==",
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/slider": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/@react-types/slider/-/slider-3.7.1.tgz",
-      "integrity": "sha512-FKO3YZYdrBs00XbBW5acP+0L1cCdevl/uRJiXbnLpGysO5PrSFIRS7Wlv4M7ztf6gT7b1Ao4FNC9crbxBr6BzA==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/table": {
-      "version": "3.9.3",
-      "resolved": "https://registry.npmjs.org/@react-types/table/-/table-3.9.3.tgz",
-      "integrity": "sha512-Hs/pMbxJdga2zBol4H5pV1FVIiRjCuSTXst6idJjkctanTexR4xkyrtBwl+rdLNoGwQ2pGii49vgklc5bFK7zA==",
-      "dependencies": {
-        "@react-types/grid": "^3.2.4",
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/tabs": {
-      "version": "3.3.5",
-      "resolved": "https://registry.npmjs.org/@react-types/tabs/-/tabs-3.3.5.tgz",
-      "integrity": "sha512-6NTSZBOWekCtApdZrhu5tHhE/8q52oVohQN+J5T7shAXd6ZAtu8PABVR/nH4BWucc8FL0OUajRqunqzQMU13gA==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/textfield": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/@react-types/textfield/-/textfield-3.9.1.tgz",
-      "integrity": "sha512-JBHY9M2CkL6xFaGSfWmUJVu3tEK09FaeB1dU3IEh6P41xxbFnPakYHSSAdnwMXBtXPoSHIVsUBickW/pjgfe5g==",
-      "dependencies": {
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/@react-types/tooltip": {
-      "version": "3.4.7",
-      "resolved": "https://registry.npmjs.org/@react-types/tooltip/-/tooltip-3.4.7.tgz",
-      "integrity": "sha512-rV4HZRQxLRNhe24yATOxnFQtGRUmsR7mqxMupXCmd1vrw8h+rdKlQv1zW2q8nALAKNmnRXZJHxYQ1SFzb98fgg==",
-      "dependencies": {
-        "@react-types/overlays": "^3.8.5",
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
     "node_modules/@rneui/base": {
       "version": "4.0.0-rc.7",
       "resolved": "https://registry.npmjs.org/@rneui/base/-/base-4.0.0-rc.7.tgz",
@@ -8433,14 +6694,6 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
-    "node_modules/@swc/helpers": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.7.tgz",
-      "integrity": "sha512-BVvNZhx362+l2tSwSuyEUV4h7+jk9raNdoTSdLfwTshXJSaGmYKluGRJznziCI3KX02Z19DdsQrdfrpXAU3Hfg==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@tanstack/query-core": {
       "version": "5.28.6",
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.28.6.tgz",
@@ -8508,16 +6761,6 @@
         "csstype": "^3.0.2"
       }
     },
-    "node_modules/@types/react-native": {
-      "version": "0.73.0",
-      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.73.0.tgz",
-      "integrity": "sha512-6ZRPQrYM72qYKGWidEttRe6M5DZBEV5F+MHMHqd4TTYx0tfkcdrUFGdef6CCxY0jXU7wldvd/zA/b0A/kTeJmA==",
-      "deprecated": "This is a stub types definition. react-native provides its own type definitions, so you do not need this installed.",
-      "peer": true,
-      "dependencies": {
-        "react-native": "*"
-      }
-    },
     "node_modules/@types/react-native-vector-icons": {
       "version": "6.4.18",
       "resolved": "https://registry.npmjs.org/@types/react-native-vector-icons/-/react-native-vector-icons-6.4.18.tgz",
@@ -8539,16 +6782,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="
-    },
-    "node_modules/@types/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-xevGOReSYGM7g/kUBZzPqCrR/KYAo+F0yiPc85WFTJa0MSLtyFTVTU6cJu/aV4mid7IffDIWqo69THF2o4JiEQ=="
-    },
-    "node_modules/@types/strip-json-comments": {
-      "version": "0.0.30",
-      "resolved": "https://registry.npmjs.org/@types/strip-json-comments/-/strip-json-comments-0.0.30.tgz",
-      "integrity": "sha512-7NQmHra/JILCd1QqpSzl8+mJRc8ZHz3uDm8YV1Ks9IhK0epEiTw8aIErbvH9PI+6XbqhyIQy3462nEsn7UVzjQ=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.32",
@@ -8989,18 +7222,6 @@
         "node": ">=0.6"
       }
     },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/bl": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -9282,24 +7503,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/camelcase-css": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
-      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
-      "peer": true,
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/camelize": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/camelize/-/camelize-1.0.1.tgz",
-      "integrity": "sha512-dU+Tx2fsypxTgtLoE36npi3UqcjSSMNYfkqgmoEhtZrraP5VWq0K7FkWVTYa8eMPtnU/G2txVsfdCJTn9uzpuQ==",
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001597",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001597.tgz",
@@ -9338,30 +7541,6 @@
       "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "peer": true,
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
       }
     },
     "node_modules/chownr": {
@@ -9534,14 +7713,6 @@
         "kind-of": "^6.0.2",
         "shallow-clone": "^3.0.0"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.0.tgz",
-      "integrity": "sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==",
       "engines": {
         "node": ">=6"
       }
@@ -9794,29 +7965,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/css-color-keywords": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/css-color-keywords/-/css-color-keywords-1.0.0.tgz",
-      "integrity": "sha512-FyyrDHZKEjXDpNJYvVsV960FiqQyXc/LlYmsxl2BcdMb2WPx0OGRVgTg55rPSyLSNMqP52R9r8geSp7apN3Ofg==",
-      "peer": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/css-in-js-utils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/css-in-js-utils/-/css-in-js-utils-3.1.0.tgz",
-      "integrity": "sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==",
-      "dependencies": {
-        "hyphenate-style-name": "^1.0.3"
-      }
-    },
-    "node_modules/css-mediaquery": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
-      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
-      "peer": true
-    },
     "node_modules/css-select": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
@@ -9830,17 +7978,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/css-to-react-native": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-3.2.0.tgz",
-      "integrity": "sha512-e8RKaLXMOFii+02mOlqwjbD00KSEKqblnpO9e++1aXS1fPQOpS1YoqdVHBqPjHNoxeF2mimzVqawm2KCbEdtHQ==",
-      "peer": true,
-      "dependencies": {
-        "camelize": "^1.0.0",
-        "css-color-keywords": "^1.0.0",
-        "postcss-value-parser": "^4.0.2"
       }
     },
     "node_modules/css-tree": {
@@ -9872,18 +8009,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
-      }
-    },
-    "node_modules/cssesc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
-      "peer": true,
-      "bin": {
-        "cssesc": "bin/cssesc"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/csstype": {
@@ -10077,12 +8202,6 @@
         "node": ">=0.10"
       }
     },
-    "node_modules/didyoumean": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
-      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
-      "peer": true
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -10092,21 +8211,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dlv": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
-      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
-      "peer": true
-    },
-    "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
-      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
-      "dependencies": {
-        "@babel/runtime": "^7.8.7",
-        "csstype": "^3.0.2"
       }
     },
     "node_modules/dom-serializer": {
@@ -10559,12 +8663,6 @@
       "resolved": "https://registry.npmjs.org/expo-status-bar/-/expo-status-bar-1.11.1.tgz",
       "integrity": "sha512-ddQEtCOgYHTLlFUe/yH67dDBIoct5VIULthyT3LRJbEwdpzAgueKsX2FYK02ldh440V87PWKCamh7R9evk1rrg=="
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "peer": true
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10584,11 +8682,6 @@
       "engines": {
         "node": ">=8.6.0"
       }
-    },
-    "node_modules/fast-loops": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/fast-loops/-/fast-loops-1.1.3.tgz",
-      "integrity": "sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g=="
     },
     "node_modules/fast-xml-parser": {
       "version": "4.3.5",
@@ -11152,11 +9245,6 @@
         "node": ">=10.17.0"
       }
     },
-    "node_modules/hyphenate-style-name": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.4.tgz",
-      "integrity": "sha512-ygGZLjmXfPHj+ZWh6LwbC37l43MhfztxetbFCoYTM2VjkIUpeHgSNn7QIyVFj7YQ1Wl9Cbw5sholVJPzWvC2MQ=="
-    },
     "node_modules/idb": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
@@ -11263,15 +9351,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
     },
-    "node_modules/inline-style-prefixer": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/inline-style-prefixer/-/inline-style-prefixer-6.0.4.tgz",
-      "integrity": "sha512-FwXmZC2zbeeS7NzGjJ6pAiqRhXR0ugUShSNb6GApMl6da0/XGc4MOJsoWAywia52EEWbXNSy0pzkwz/+Y+swSg==",
-      "dependencies": {
-        "css-in-js-utils": "^3.1.0",
-        "fast-loops": "^1.1.3"
-      }
-    },
     "node_modules/internal-ip": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/internal-ip/-/internal-ip-4.3.0.tgz",
@@ -11282,17 +9361,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/intl-messageformat": {
-      "version": "10.5.11",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.5.11.tgz",
-      "integrity": "sha512-eYq5fkFBVxc7GIFDzpFQkDOZgNayNTQn4Oufe8jw6YY6OHVw70/4pA3FyCsQ0Gb2DnvEJEMmN2tOaXUGByM+kg==",
-      "dependencies": {
-        "@formatjs/ecma402-abstract": "1.18.2",
-        "@formatjs/fast-memoize": "2.2.0",
-        "@formatjs/icu-messageformat-parser": "2.7.6",
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/invariant": {
@@ -11323,18 +9391,6 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "peer": true,
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
     },
     "node_modules/is-buffer": {
       "version": "1.1.6",
@@ -11931,15 +9987,6 @@
       "resolved": "https://registry.npmjs.org/jimp-compact/-/jimp-compact-0.16.1.tgz",
       "integrity": "sha512-dZ6Ra7u1G8c4Letq/B5EzAxj4tLFHL+cGtdpR+PVm4yzPDj+lCk+AbivWt1eOM+ikzkowtyV7qSqX6qr3t71Ww=="
     },
-    "node_modules/jiti": {
-      "version": "1.21.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
-      "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
-      "peer": true,
-      "bin": {
-        "jiti": "bin/jiti.js"
-      }
-    },
     "node_modules/joi": {
       "version": "17.12.2",
       "resolved": "https://registry.npmjs.org/joi/-/joi-17.12.2.tgz",
@@ -12159,15 +10206,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/legacy-swc-helpers": {
-      "name": "@swc/helpers",
-      "version": "0.4.14",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.4.14.tgz",
-      "integrity": "sha512-4C7nX/dvpzB7za4Ql9K81xK3HPxCpHMgwTZVyf+9JQ6VUbn9jjZVN7/Nkdz/Ugzs2CSjqnL/UPXroiVBVHUWUw==",
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -12373,15 +10411,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
-    },
-    "node_modules/lilconfig": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-      "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/lines-and-columns": {
@@ -13433,65 +11462,6 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
-    "node_modules/nativewind": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/nativewind/-/nativewind-2.0.11.tgz",
-      "integrity": "sha512-qCEXUwKW21RYJ33KRAJl3zXq2bCq82WoI564fI21D/TiqhfmstZOqPN53RF8qK1NDK6PGl56b2xaTxgObEePEg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/generator": "^7.18.7",
-        "@babel/helper-module-imports": "7.18.6",
-        "@babel/types": "7.19.0",
-        "css-mediaquery": "^0.1.2",
-        "css-to-react-native": "^3.0.0",
-        "micromatch": "^4.0.5",
-        "postcss": "^8.4.12",
-        "postcss-calc": "^8.2.4",
-        "postcss-color-functional-notation": "^4.2.2",
-        "postcss-css-variables": "^0.18.0",
-        "postcss-nested": "^5.0.6",
-        "react-is": "^18.1.0",
-        "use-sync-external-store": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=14.18"
-      },
-      "peerDependencies": {
-        "tailwindcss": "~3"
-      }
-    },
-    "node_modules/nativewind/node_modules/@babel/helper-module-imports": {
-      "version": "7.18.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-      "integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/types": "^7.18.6"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/nativewind/node_modules/@babel/types": {
-      "version": "7.19.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.19.0.tgz",
-      "integrity": "sha512-YuGopBq3ke25BVSiS6fgF49Ul9gH1x70Bcr6bqRLjWCkcX8Hre1/5+z+IiWOIerRMSSEfGZVB9z9kyq7wVs9YA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/helper-string-parser": "^7.18.10",
-        "@babel/helper-validator-identifier": "^7.18.6",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/nativewind/node_modules/react-is": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "peer": true
-    },
     "node_modules/ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
@@ -13597,11 +11567,6 @@
         "url": "https://github.com/sponsors/antelle"
       }
     },
-    "node_modules/normalize-css-color": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/normalize-css-color/-/normalize-css-color-1.0.2.tgz",
-      "integrity": "sha512-jPJ/V7Cp1UytdidsPqviKEElFQJs22hUUgK5BOPHTwOonNCk7/2qOxhhqzEajmFrWJowADFfOFh1V+aWkRfy+w=="
-    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -13670,15 +11635,6 @@
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/object-hash": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
-      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
-      "peer": true,
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/on-finished": {
@@ -14128,173 +12084,6 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/postcss-calc": {
-      "version": "8.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
-      "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
-      "peer": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.9",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.2"
-      }
-    },
-    "node_modules/postcss-color-functional-notation": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/postcss-color-functional-notation/-/postcss-color-functional-notation-4.2.4.tgz",
-      "integrity": "sha512-2yrTAUZUab9s6CpxkxC4rVgFEVaR6/2Pipvi6qcgvnYiVqZcbDHEoBDhrXzyb7Efh2CCfHQNtcqWcIruDTIUeg==",
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.2.0"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >=16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/csstools"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2"
-      }
-    },
-    "node_modules/postcss-css-variables": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/postcss-css-variables/-/postcss-css-variables-0.18.0.tgz",
-      "integrity": "sha512-lYS802gHbzn1GI+lXvy9MYIYDuGnl1WB4FTKoqMQqJ3Mab09A7a/1wZvGTkCEZJTM8mSbIyb1mJYn8f0aPye0Q==",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "escape-string-regexp": "^1.0.3",
-        "extend": "^3.0.1"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.6"
-      }
-    },
-    "node_modules/postcss-import": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
-      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
-      "peer": true,
-      "dependencies": {
-        "postcss-value-parser": "^4.0.0",
-        "read-cache": "^1.0.0",
-        "resolve": "^1.1.7"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "postcss": "^8.0.0"
-      }
-    },
-    "node_modules/postcss-js": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.0.1.tgz",
-      "integrity": "sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==",
-      "peer": true,
-      "dependencies": {
-        "camelcase-css": "^2.0.1"
-      },
-      "engines": {
-        "node": "^12 || ^14 || >= 16"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.4.21"
-      }
-    },
-    "node_modules/postcss-load-config": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-4.0.2.tgz",
-      "integrity": "sha512-bSVhyJGL00wMVoPUzAVAnbEoWyqRxkjv64tUl427SKnPrENtq6hJwUojroMz2VB+Q1edmi4IfrAPpami5VVgMQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "peer": true,
-      "dependencies": {
-        "lilconfig": "^3.0.0",
-        "yaml": "^2.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      },
-      "peerDependencies": {
-        "postcss": ">=8.0.9",
-        "ts-node": ">=9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "postcss": {
-          "optional": true
-        },
-        "ts-node": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/postcss-load-config/node_modules/lilconfig": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
-      "integrity": "sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antonk52"
-      }
-    },
-    "node_modules/postcss-nested": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-5.0.6.tgz",
-      "integrity": "sha512-rKqm2Fk0KbA8Vt3AdGN0FB9OBOMDVajMG6ZCf/GoHgdxUJ4sBFp0A/uMIRm+MJUdo33YXEtjqIz8u7DAp8B7DA==",
-      "peer": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.6"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.14"
-      }
-    },
-    "node_modules/postcss-selector-parser": {
-      "version": "6.0.16",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
-      "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
-      "peer": true,
-      "dependencies": {
-        "cssesc": "^3.0.0",
-        "util-deprecate": "^1.0.2"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "peer": true
-    },
     "node_modules/pretty-bytes": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
@@ -14614,28 +12403,6 @@
         }
       }
     },
-    "node_modules/react-dom": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
-      "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.0"
-      },
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
-    },
-    "node_modules/react-dom/node_modules/scheduler": {
-      "version": "0.23.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
-      "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
-    },
     "node_modules/react-freeze": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/react-freeze/-/react-freeze-1.0.4.tgz",
@@ -14914,32 +12681,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/react-native-web": {
-      "version": "0.19.10",
-      "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.19.10.tgz",
-      "integrity": "sha512-IQoHiTQq8egBCVVwmTrYcFLgEFyb4LMZYEktHn4k22JMk9+QTCEz5WTfvr+jdNoeqj/7rtE81xgowKbfGO74qg==",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.18.6",
-        "@react-native/normalize-color": "^2.1.0",
-        "fbjs": "^3.0.4",
-        "inline-style-prefixer": "^6.0.1",
-        "memoize-one": "^6.0.0",
-        "nullthrows": "^1.1.1",
-        "postcss-value-parser": "^4.2.0",
-        "styleq": "^0.1.3"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0",
-        "react-dom": "^18.0.0"
-      }
-    },
-    "node_modules/react-native-web/node_modules/memoize-one": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-6.0.0.tgz",
-      "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
-      "peer": true
-    },
     "node_modules/react-native/node_modules/ansi-styles": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -15045,57 +12786,6 @@
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
       }
     },
-    "node_modules/react-stately": {
-      "version": "3.30.1",
-      "resolved": "https://registry.npmjs.org/react-stately/-/react-stately-3.30.1.tgz",
-      "integrity": "sha512-IEhKHMT7wijtczA5vtw/kdq9CZuOIF+ReoSimydTFiABRQxWO9ESAl/fToXOUM9qmCdhdqjGJgMAhqTnmheh8g==",
-      "dependencies": {
-        "@react-stately/calendar": "^3.4.4",
-        "@react-stately/checkbox": "^3.6.3",
-        "@react-stately/collections": "^3.10.5",
-        "@react-stately/combobox": "^3.8.2",
-        "@react-stately/data": "^3.11.2",
-        "@react-stately/datepicker": "^3.9.2",
-        "@react-stately/dnd": "^3.2.8",
-        "@react-stately/form": "^3.0.1",
-        "@react-stately/list": "^3.10.3",
-        "@react-stately/menu": "^3.6.1",
-        "@react-stately/numberfield": "^3.9.1",
-        "@react-stately/overlays": "^3.6.5",
-        "@react-stately/radio": "^3.10.2",
-        "@react-stately/searchfield": "^3.5.1",
-        "@react-stately/select": "^3.6.2",
-        "@react-stately/selection": "^3.14.3",
-        "@react-stately/slider": "^3.5.2",
-        "@react-stately/table": "^3.11.6",
-        "@react-stately/tabs": "^3.6.4",
-        "@react-stately/toggle": "^3.7.2",
-        "@react-stately/tooltip": "^3.4.7",
-        "@react-stately/tree": "^3.7.6",
-        "@react-types/shared": "^3.22.1"
-      },
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
-      }
-    },
-    "node_modules/read-cache": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
-      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
-      "peer": true,
-      "dependencies": {
-        "pify": "^2.3.0"
-      }
-    },
-    "node_modules/read-cache/node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -15108,30 +12798,6 @@
         "safe-buffer": "~5.1.1",
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "peer": true,
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
-    "node_modules/readdirp/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "peer": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/readline": {
@@ -15803,14 +13469,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
@@ -15844,12 +13502,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/structured-headers/-/structured-headers-0.4.1.tgz",
       "integrity": "sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg=="
-    },
-    "node_modules/styleq": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/styleq/-/styleq-0.1.3.tgz",
-      "integrity": "sha512-3ZUifmCDCQanjeej1f6kyl/BeP/Vae5EYkQ9iJfUm/QwZvlgnZzyflqAsAWYURdtea8Vkvswu2GrC57h3qffcA==",
-      "peer": true
     },
     "node_modules/sucrase": {
       "version": "3.34.0",
@@ -15955,74 +13607,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/tailwindcss": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.1.tgz",
-      "integrity": "sha512-qAYmXRfk3ENzuPBakNK0SRrUDipP8NQnEY6772uDhflcQz5EhRdD7JNZxyrFHVQNCwULPBn6FNPp9brpO7ctcA==",
-      "peer": true,
-      "dependencies": {
-        "@alloc/quick-lru": "^5.2.0",
-        "arg": "^5.0.2",
-        "chokidar": "^3.5.3",
-        "didyoumean": "^1.2.2",
-        "dlv": "^1.1.3",
-        "fast-glob": "^3.3.0",
-        "glob-parent": "^6.0.2",
-        "is-glob": "^4.0.3",
-        "jiti": "^1.19.1",
-        "lilconfig": "^2.1.0",
-        "micromatch": "^4.0.5",
-        "normalize-path": "^3.0.0",
-        "object-hash": "^3.0.0",
-        "picocolors": "^1.0.0",
-        "postcss": "^8.4.23",
-        "postcss-import": "^15.1.0",
-        "postcss-js": "^4.0.1",
-        "postcss-load-config": "^4.0.1",
-        "postcss-nested": "^6.0.1",
-        "postcss-selector-parser": "^6.0.11",
-        "resolve": "^1.22.2",
-        "sucrase": "^3.32.0"
-      },
-      "bin": {
-        "tailwind": "lib/cli.js",
-        "tailwindcss": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "peer": true,
-      "dependencies": {
-        "is-glob": "^4.0.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
-    "node_modules/tailwindcss/node_modules/postcss-nested": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.0.1.tgz",
-      "integrity": "sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==",
-      "peer": true,
-      "dependencies": {
-        "postcss-selector-parser": "^6.0.11"
-      },
-      "engines": {
-        "node": ">=12.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.14"
       }
     },
     "node_modules/tar": {
@@ -16279,17 +13863,6 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="
     },
-    "node_modules/tsconfig": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/tsconfig/-/tsconfig-7.0.0.tgz",
-      "integrity": "sha512-vZXmzPrL+EmC4T/4rVlT2jNVMWCi/O4DIiSj3UHg1OE5kCKbk4mfrXc6dZksLgRM/TZlKnousKH9bbTazUWRRw==",
-      "dependencies": {
-        "@types/strip-bom": "^3.0.0",
-        "@types/strip-json-comments": "0.0.30",
-        "strip-bom": "^3.0.0",
-        "strip-json-comments": "^2.0.0"
-      }
-    },
     "node_modules/tslib": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
@@ -16312,18 +13885,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
       }
     },
     "node_modules/ua-parser-js": {
@@ -16483,15 +14044,6 @@
       "integrity": "sha512-CL/29uS74AwreI/f2oz2hLTW7ZqVeV5+gxFeGudzQrgkCytrHw33G4KbnQOrRlAEzzAFXi7dDLMC9zhWcVpzmw==",
       "peerDependencies": {
         "react": ">=16.8"
-      }
-    },
-    "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "peer": true,
-      "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util-deprecate": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,6 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@gluestack-style/react": "^1.0.52",
-    "@gluestack-ui/config": "^1.1.18",
-    "@gluestack-ui/themed": "^1.1.17",
     "@react-native-async-storage/async-storage": "^1.22.3",
     "@react-native-community/datetimepicker": "^7.6.3",
     "@react-native-picker/picker": "^2.7.2",

--- a/src/components/features/auth/AuthForm.jsx
+++ b/src/components/features/auth/AuthForm.jsx
@@ -1,4 +1,4 @@
-import { Text, StyleSheet, Alert } from "react-native";
+import { Text, StyleSheet, Alert, ActivityIndicator } from "react-native";
 import React, { useCallback, useState } from "react";
 import InputWithLabel from "../../ui/InputWithLabel";
 import PressableButton from "../../ui/PressableButton";
@@ -7,7 +7,6 @@ import { Colors } from "../../../utils/Colors";
 import { getDefaultUserName, isValidEmail } from "../../../utils/helper";
 import { doc, setDoc } from "firebase/firestore";
 import { db, auth } from "../../../api/FirestoreConfig";
-import { Spinner } from "@gluestack-ui/themed";
 import {
   createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
@@ -187,7 +186,10 @@ export default function AuthForm({ mode }) {
         {isSubmitting && (
           <>
             <Text style={styles.submitBtnText}>Loading...</Text>
-            <Spinner marginLeft={10} color={Colors.lighterThanBg} />
+            <ActivityIndicator
+              style={{ marginLeft: 10 }}
+              color={Colors.lighterThanBg}
+            />
           </>
         )}
       </PressableButton>

--- a/src/components/features/dashboard/TaskBreakdown.jsx
+++ b/src/components/features/dashboard/TaskBreakdown.jsx
@@ -40,7 +40,7 @@ export default function TaskBreakdown() {
     let focusedInd = 0;
     if (obj.id) focusedInd = pieData.findIndex((item) => item.id === obj.id);
     else focusedInd = -1;
-    console.log(obj, focusedInd);
+
     setPieData(
       pieData.map((item, ind) => ({
         ...item,

--- a/src/components/features/findGroup/GroupResultsItem.jsx
+++ b/src/components/features/findGroup/GroupResultsItem.jsx
@@ -1,11 +1,10 @@
-import { View, Text, StyleSheet } from "react-native";
+import { View, Text, StyleSheet, ActivityIndicator } from "react-native";
 import React from "react";
 import GroupInfoBox from "../studyGroup/GroupInfoBox";
 import PressableButton from "../../ui/PressableButton";
 import { Colors } from "../../../utils/Colors";
 import { AntDesign } from "@expo/vector-icons";
 import useJoinGroup from "./useJoinGroup";
-import { Spinner } from "@gluestack-ui/themed";
 import GroupResultsItemSkeleton from "./GroupResultsItemSkeleton";
 
 export default function GroupResultsItem({
@@ -39,8 +38,8 @@ export default function GroupResultsItem({
               {isJoining && (
                 <>
                   <Text style={styles.joinBtnText}>Joining...</Text>
-                  <Spinner
-                    marginLeft={5}
+                  <ActivityIndicator
+                    style={{ marginLeft: 5 }}
                     size={20}
                     color={Colors.screenBgColor}
                   />

--- a/src/components/features/findGroup/GroupResultsList.jsx
+++ b/src/components/features/findGroup/GroupResultsList.jsx
@@ -21,7 +21,7 @@ export default function GroupResultsList({ keyword }) {
             loop={false}
           />
           <Text style={styles.placeholderText}>
-            Input a keyword above to start search
+            Input group's name to find groups
           </Text>
         </View>
       )}

--- a/src/components/features/studyGroup/GroupDetailHeaderMenu.jsx
+++ b/src/components/features/studyGroup/GroupDetailHeaderMenu.jsx
@@ -1,15 +1,39 @@
-import { Alert, StyleSheet } from "react-native";
-import React from "react";
+import { Alert, StyleSheet, Text, View } from "react-native";
+import React, { useCallback, useState } from "react";
 import { Entypo } from "@expo/vector-icons";
 import { Colors } from "../../../utils/Colors";
-import { Button, Menu, MenuItem, MenuItemLabel } from "@gluestack-ui/themed";
 import { AntDesign } from "@expo/vector-icons";
 import { getUserRef } from "../../../utils/helper";
 import useQuitGroup from "./useQuitGroup";
 import { useNavigation } from "@react-navigation/native";
+import { Overlay } from "@rneui/themed";
+import PressableButton from "../../ui/PressableButton";
+
+function Menu({ toggleMenu, triggerAlert }) {
+  const quitOption = "Quit Group";
+  return (
+    <Overlay
+      backdropStyle={styles.menuBackdrop}
+      fullScreen={false}
+      overlayStyle={styles.menu}
+      onBackdropPress={toggleMenu}
+    >
+      <PressableButton containerStyle={styles.menuLine} onPress={triggerAlert}>
+        <AntDesign
+          name="closecircleo"
+          size={24}
+          color="black"
+          style={styles.menuIcon}
+        />
+        <Text style={styles.menuText}>{quitOption}</Text>
+      </PressableButton>
+    </Overlay>
+  );
+}
 
 export default function GroupDetailHeaderMenu({ groupId, groupOwnerId }) {
   const navigation = useNavigation();
+  const [showMenu, setShowMenu] = useState(false);
   const userRef = getUserRef();
   const curUserId = userRef.id;
   const isOwner = curUserId === groupOwnerId;
@@ -19,8 +43,6 @@ export default function GroupDetailHeaderMenu({ groupId, groupOwnerId }) {
     quitGroup(groupId);
     navigation.goBack();
   };
-
-  const quitOption = "Quit Group";
 
   const alertMsg = isOwner
     ? "You are the owner of the group. Once quit, the group will be deleted. Are you sure to quit?"
@@ -33,51 +55,48 @@ export default function GroupDetailHeaderMenu({ groupId, groupOwnerId }) {
     ]);
   };
 
+  const toggleMenu = useCallback(() => {
+    setShowMenu((show) => !show);
+  }, []);
+
   return (
-    <Menu
-      placement="bottom right"
-      trigger={({ ...triggerProps }) => (
-        <Button {...triggerProps} style={{ backgroundColor: "transparent" }}>
-          <Entypo
-            name="dots-three-horizontal"
-            size={24}
-            color={Colors.headerTitleColor}
-          />
-        </Button>
-      )}
-      style={styles.menu}
-      offset={5}
-    >
-      <MenuItem
-        key={quitOption}
-        textValue={quitOption}
-        style={styles.menuItemContainer}
-        onPress={triggerAlert}
-      >
-        <AntDesign
-          name="closecircleo"
+    <>
+      <PressableButton onPress={toggleMenu}>
+        <Entypo
+          name="dots-three-horizontal"
           size={24}
-          color="black"
-          style={styles.closeIcon}
+          color={Colors.headerTitleColor}
         />
-        <MenuItemLabel>{quitOption}</MenuItemLabel>
-      </MenuItem>
-    </Menu>
+      </PressableButton>
+      {showMenu && <Menu toggleMenu={toggleMenu} triggerAlert={triggerAlert} />}
+    </>
   );
 }
 
 const styles = StyleSheet.create({
+  menuBackdrop: {
+    backgroundColor: "transparent",
+  },
   menu: {
-    minWidth: 180,
+    width: 180,
+    height: 60,
+    justifyContent: "center",
+    top: 100,
+    right: 10,
+    borderRadius: 10,
+    position: "absolute",
     shadowColor: "black",
     shadowRadius: 30,
     shadowOffset: { width: -20, height: 10 },
     shadowOpacity: 0.2,
   },
-  menuItemContainer: {
-    width: 180,
-  },
-  closeIcon: {
+  menuIcon: {
     marginHorizontal: 10,
+  },
+  menuText: { fontSize: 16 },
+
+  menuLine: {
+    flexDirection: "row",
+    alignItems: "center",
   },
 });

--- a/src/components/ui/FormOperationBar.jsx
+++ b/src/components/ui/FormOperationBar.jsx
@@ -1,8 +1,7 @@
-import { View, StyleSheet, Text } from "react-native";
+import { View, StyleSheet, Text, ActivityIndicator } from "react-native";
 import React, { useCallback, useEffect, useState } from "react";
 import PressableButton from "./PressableButton";
 import { Colors } from "../../utils/Colors";
-import { Spinner } from "@gluestack-ui/themed";
 import Animated, {
   ReduceMotion,
   useSharedValue,
@@ -70,7 +69,10 @@ export default function FormOperationBar({
               <Text numberOfLines={1} style={styles.confirmBtnText}>
                 Loading...
               </Text>
-              <Spinner marginLeft={5} color={Colors.shallowTextColor} />
+              <ActivityIndicator
+                style={{ marginLeft: 5 }}
+                color={Colors.shallowTextColor}
+              />
             </>
           ) : (
             <Text style={styles.confirmBtnText}>{confirmText}</Text>


### PR DESCRIPTION
Gluestack's components include some old components who relies on an old version of React, so all components related to it have been replaced with other ones. Now npm install won't show any warning.